### PR TITLE
Change to release version of zap logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import (
 
 	"github.com/IBM-Bluemix/go-etcd-rules/rules"
 	"github.com/coreos/etcd/client"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,8 @@
-hash: e4a810cc6f6ec0e52c322689e5ff836dbac8296221bc863802d7c77267027063
-updated: 2017-01-17T14:40:54.701213613-05:00
+hash: 687e226fa36a3193a97c8bed497a9da1f0e6a4a3e14b3aba53ace8323778577e
+updated: 2017-03-30T11:25:34.301338594+01:00
 imports:
-- name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-  subpackages:
-  - quantile
 - name: github.com/coreos/etcd
-  version: 2db9d3b70236f620c3c507c6bf7013da5e78a9f7
+  version: 36735d52a4fde4d3d7e568d15c212d83970a7aab
   subpackages:
   - auth/authpb
   - client
@@ -16,17 +12,17 @@ imports:
   - etcdserver/etcdserverpb
   - mvcc/mvccpb
   - pkg/pathutil
-  - pkg/tlsutil
   - pkg/types
-- name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+  - version
+- name: github.com/coreos/go-semver
+  version: 568e959cd89871e61434c1143528d9162da89ef2
+  subpackages:
+  - semver
 - name: github.com/golang/protobuf
   version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - jsonpb
   - proto
-- name: github.com/grpc-ecosystem/go-grpc-prometheus
-  version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: 84398b94e188ee336f307779b57b3aa91af7063c
   subpackages:
@@ -34,44 +30,33 @@ imports:
   - runtime/internal
   - utilities
 - name: github.com/IBM-Bluemix/go-etcd-lock
-  version: 0445a1f78d4b4e9cdadc83d2e721bb949f95d70f
+  version: 5b2bceba5526ce1d039c115619da2238c47ee76b
   subpackages:
   - lock
-- name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
-  subpackages:
-  - pbutil
-- name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
-  subpackages:
-  - prometheus
-- name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
-- name: github.com/prometheus/common
-  version: dd2f054febf4a6c00f2343686efb775948a8bff4
-  subpackages:
-  - expfmt
-  - internal/bitbucket.org/ww/goautoneg
-  - model
-- name: github.com/prometheus/procfs
-  version: fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60
-- name: github.com/uber-go/atomic
-  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
-- name: github.com/uber-go/zap
-  version: a5783ee4b216a927da8f839c45cfbf9d694e1467
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
+- name: go.uber.org/atomic
+  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
+- name: go.uber.org/zap
+  version: 4257c7cf05477d92ec25c31cfd3d60e89575f18a
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore
 - name: golang.org/x/net
-  version: 6acef71eb69611914f7a30939ea9f6e194c78172
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
   - http2
   - http2/hpack
+  - idna
   - internal/timeseries
+  - lex/httplex
   - trace
 - name: google.golang.org/grpc
   version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
@@ -86,11 +71,9 @@ imports:
   - transport
 - name: gopkg.in/errgo.v1
   version: 442357a80af5c6bf9b6d51ae791a39c3421004f3
-- name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
@@ -98,6 +81,6 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 687e226fa36a3193a97c8bed497a9da1f0e6a4a3e14b3aba53ace8323778577e
-updated: 2017-03-30T11:25:34.301338594+01:00
+updated: 2017-04-24T17:29:10.443642411+01:00
 imports:
 - name: github.com/coreos/etcd
-  version: 36735d52a4fde4d3d7e568d15c212d83970a7aab
+  version: f254e383859a2939d5929346f6595549f424f7c5
   subpackages:
   - auth/authpb
   - client
@@ -23,14 +23,8 @@ imports:
   subpackages:
   - jsonpb
   - proto
-- name: github.com/grpc-ecosystem/grpc-gateway
-  version: 84398b94e188ee336f307779b57b3aa91af7063c
-  subpackages:
-  - runtime
-  - runtime/internal
-  - utilities
 - name: github.com/IBM-Bluemix/go-etcd-lock
-  version: 5b2bceba5526ce1d039c115619da2238c47ee76b
+  version: 494c016f0a0e15cb328987cb716b01a1580633b8
   subpackages:
   - lock
 - name: github.com/ugorji/go
@@ -38,9 +32,9 @@ imports:
   subpackages:
   - codec
 - name: go.uber.org/atomic
-  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
+  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: go.uber.org/zap
-  version: 4257c7cf05477d92ec25c31cfd3d60e89575f18a
+  version: 1550bc05539134bbf8612a35f34a79ab8bf34ee3
   subpackages:
   - buffer
   - internal/bufferpool
@@ -49,7 +43,7 @@ imports:
   - internal/multierror
   - zapcore
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: c8c74377599bd978aee1cf3b9b63a8634051cec2
   subpackages:
   - context
   - http2
@@ -58,16 +52,26 @@ imports:
   - internal/timeseries
   - lex/httplex
   - trace
+- name: golang.org/x/text
+  version: a9a820217f98f7c8a207ec1e45a874e1fe12c478
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
 - name: google.golang.org/grpc
-  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+  version: 8050b9cbc271307e5a716a9d782803d09b0d6f2d
   subpackages:
   - codes
   - credentials
   - grpclog
   - internal
+  - keepalive
   - metadata
   - naming
   - peer
+  - stats
+  - tap
   - transport
 - name: gopkg.in/errgo.v1
   version: 442357a80af5c6bf9b6d51ae791a39c3421004f3

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
   version: master
   subpackages:
   - client
-- package: github.com/uber-go/zap
+- package: go.uber.org/zap
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/rules/crawler.go
+++ b/rules/crawler.go
@@ -18,7 +18,7 @@ type crawler interface {
 
 func newCrawler(
 	config client.Config,
-	logger zap.Logger,
+	logger *zap.Logger,
 	prefix string,
 	interval int,
 	kp keyProc,
@@ -49,7 +49,7 @@ func newV3Crawler(
 	config clientv3.Config,
 	interval int,
 	kp keyProc,
-	logger zap.Logger,
+	logger *zap.Logger,
 	mutex *string,
 	mutexTTL int,
 	prefix string,
@@ -85,7 +85,7 @@ type baseCrawler struct {
 	cancelMutex sync.Mutex
 	interval    int
 	kp          keyProc
-	logger      zap.Logger
+	logger      *zap.Logger
 	mutex       *string
 	mutexTTL    int
 	prefix      string

--- a/rules/crawler.go
+++ b/rules/crawler.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
 

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
 

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -25,7 +25,7 @@ type BaseEngine interface {
 type baseEngine struct {
 	cCloser      channelCloser
 	keyProc      setableKeyProcessor
-	logger       zap.Logger
+	logger       *zap.Logger
 	options      engineOptions
 	ruleLockTTLs map[int]int
 	ruleMgr      ruleManager

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -78,18 +78,18 @@ type V3Engine interface {
 }
 
 // NewEngine creates a new Engine instance.
-func NewEngine(config client.Config, logger zap.Logger, options ...EngineOption) Engine {
+func NewEngine(config client.Config, logger *zap.Logger, options ...EngineOption) Engine {
 	eng := newEngine(config, clientv3.Config{}, false, logger, options...)
 	return &eng
 }
 
 // NewV3Engine creates a new V3Engine instance.
-func NewV3Engine(configV3 clientv3.Config, logger zap.Logger, options ...EngineOption) V3Engine {
+func NewV3Engine(configV3 clientv3.Config, logger *zap.Logger, options ...EngineOption) V3Engine {
 	eng := newV3Engine(client.Config{}, configV3, true, logger, options...)
 	return &eng
 }
 
-func newEngine(config client.Config, configV3 clientv3.Config, useV3 bool, logger zap.Logger, options ...EngineOption) engine {
+func newEngine(config client.Config, configV3 clientv3.Config, useV3 bool, logger *zap.Logger, options ...EngineOption) engine {
 	opts := makeEngineOptions(options...)
 	ruleMgr := newRuleManager(map[string]constraint{})
 	channel := make(chan ruleWork)
@@ -112,7 +112,7 @@ func newEngine(config client.Config, configV3 clientv3.Config, useV3 bool, logge
 	return eng
 }
 
-func newV3Engine(config client.Config, configV3 clientv3.Config, useV3 bool, logger zap.Logger, options ...EngineOption) v3Engine {
+func newV3Engine(config client.Config, configV3 clientv3.Config, useV3 bool, logger *zap.Logger, options ...EngineOption) v3Engine {
 	opts := makeEngineOptions(options...)
 	ruleMgr := newRuleManager(opts.constraints)
 	channel := make(chan v3RuleWork)

--- a/rules/key_processor.go
+++ b/rules/key_processor.go
@@ -7,7 +7,7 @@ import (
 )
 
 type keyProc interface {
-	processKey(key string, value *string, api readAPI, logger zap.Logger, metadata map[string]string)
+	processKey(key string, value *string, api readAPI, logger *zap.Logger, metadata map[string]string)
 }
 
 type setableKeyProcessor interface {
@@ -18,10 +18,10 @@ type setableKeyProcessor interface {
 }
 
 type workDispatcher interface {
-	dispatchWork(index int, rule staticRule, logger zap.Logger, keyPattern string, metadata map[string]string)
+	dispatchWork(index int, rule staticRule, logger *zap.Logger, keyPattern string, metadata map[string]string)
 }
 
-func (kp *keyProcessor) dispatchWork(index int, rule staticRule, logger zap.Logger, keyPattern string, metadata map[string]string) {
+func (kp *keyProcessor) dispatchWork(index int, rule staticRule, logger *zap.Logger, keyPattern string, metadata map[string]string) {
 	task := RuleTask{
 		Attr:     rule.getAttributes(),
 		Conf:     kp.config,
@@ -75,7 +75,7 @@ func (v3kp *v3KeyProcessor) setCallback(index int, callback interface{}) {
 	v3kp.callbacks[index] = callback.(V3RuleTaskCallback)
 }
 
-func (v3kp *v3KeyProcessor) dispatchWork(index int, rule staticRule, logger zap.Logger, keyPattern string, metadata map[string]string) {
+func (v3kp *v3KeyProcessor) dispatchWork(index int, rule staticRule, logger *zap.Logger, keyPattern string, metadata map[string]string) {
 	task := V3RuleTask{
 		Attr: rule.getAttributes(),
 		// This line is different
@@ -123,15 +123,15 @@ func newV3KeyProcessor(channel chan v3RuleWork, config *clientv3.Config, rm *rul
 	return kp
 }
 
-func (kp *keyProcessor) processKey(key string, value *string, api readAPI, logger zap.Logger, metadata map[string]string) {
+func (kp *keyProcessor) processKey(key string, value *string, api readAPI, logger *zap.Logger, metadata map[string]string) {
 	kp.baseKeyProcessor.processKey(key, value, api, logger, kp, metadata)
 }
 
-func (v3kp *v3KeyProcessor) processKey(key string, value *string, api readAPI, logger zap.Logger, metadata map[string]string) {
+func (v3kp *v3KeyProcessor) processKey(key string, value *string, api readAPI, logger *zap.Logger, metadata map[string]string) {
 	v3kp.baseKeyProcessor.processKey(key, value, api, logger, v3kp, metadata)
 }
 
-func (bkp *baseKeyProcessor) processKey(key string, value *string, api readAPI, logger zap.Logger, dispatcher workDispatcher, metadata map[string]string) {
+func (bkp *baseKeyProcessor) processKey(key string, value *string, api readAPI, logger *zap.Logger, dispatcher workDispatcher, metadata map[string]string) {
 	logger.Debug("Processing key", zap.String("key", key))
 	rules := bkp.rm.getStaticRules(key, value)
 	for rule, index := range rules {

--- a/rules/key_processor.go
+++ b/rules/key_processor.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 type keyProc interface {

--- a/rules/key_processor_test.go
+++ b/rules/key_processor_test.go
@@ -40,7 +40,7 @@ func TestKeyProcessor(t *testing.T) {
 type testKeyProcessor struct {
 	apis    []readAPI
 	keys    []string
-	loggers []zap.Logger
+	loggers []*zap.Logger
 	values  []*string
 }
 
@@ -55,8 +55,9 @@ func (tkp *testKeyProcessor) processKey(key string,
 	tkp.loggers = append(tkp.loggers, logger)
 }
 
-func getTestLogger() zap.Logger {
-	return zap.New(zap.NewTextEncoder())
+func getTestLogger() *zap.Logger {
+	logger, _ := zap.NewProduction()
+	return logger
 }
 
 func TestV3KeyProcessor(t *testing.T) {

--- a/rules/key_processor_test.go
+++ b/rules/key_processor_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 func TestKeyProcessor(t *testing.T) {

--- a/rules/key_processor_test.go
+++ b/rules/key_processor_test.go
@@ -47,7 +47,7 @@ type testKeyProcessor struct {
 func (tkp *testKeyProcessor) processKey(key string,
 	value *string,
 	api readAPI,
-	logger zap.Logger,
+	logger *zap.Logger,
 	metadata map[string]string) {
 	tkp.keys = append(tkp.keys, key)
 	tkp.values = append(tkp.values, value)

--- a/rules/task.go
+++ b/rules/task.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
 

--- a/rules/task.go
+++ b/rules/task.go
@@ -21,7 +21,7 @@ type Attributes interface {
 type RuleTask struct {
 	Attr     Attributes
 	Conf     client.Config
-	Logger   zap.Logger
+	Logger   *zap.Logger
 	Context  context.Context
 	Metadata map[string]string
 }
@@ -31,7 +31,7 @@ type RuleTask struct {
 type V3RuleTask struct {
 	Attr     Attributes
 	Conf     *clientv3.Config
-	Logger   zap.Logger
+	Logger   *zap.Logger
 	Context  context.Context
 	Metadata map[string]string
 }

--- a/rules/watcher.go
+++ b/rules/watcher.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 func newWatcher(config client.Config, prefix string, logger zap.Logger, proc keyProc, watchTimeout int) (watcher, error) {

--- a/rules/watcher.go
+++ b/rules/watcher.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func newWatcher(config client.Config, prefix string, logger zap.Logger, proc keyProc, watchTimeout int) (watcher, error) {
+func newWatcher(config client.Config, prefix string, logger *zap.Logger, proc keyProc, watchTimeout int) (watcher, error) {
 	ec, err := client.New(config)
 	if err != nil {
 		return watcher{}, err
@@ -28,7 +28,7 @@ func newWatcher(config client.Config, prefix string, logger zap.Logger, proc key
 	}, nil
 }
 
-func newV3Watcher(config clientv3.Config, prefix string, logger zap.Logger, proc keyProc, watchTimeout int) (watcher, error) {
+func newV3Watcher(config clientv3.Config, prefix string, logger *zap.Logger, proc keyProc, watchTimeout int) (watcher, error) {
 	ec, err := clientv3.New(config)
 	if err != nil {
 		return watcher{}, err
@@ -50,7 +50,7 @@ type watcher struct {
 	api      readAPI
 	kw       keyWatcher
 	kp       keyProc
-	logger   zap.Logger
+	logger   *zap.Logger
 	stopping uint32
 	stopped  uint32
 }

--- a/rules/worker.go
+++ b/rules/worker.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 type baseWorker struct {

--- a/rules/worker.go
+++ b/rules/worker.go
@@ -138,7 +138,7 @@ func (w *worker) singleRun() {
 	}
 	w.addWorkerID(task.Metadata)
 	task.Logger = task.Logger.With(zap.String("worker", w.workerID))
-	w.doWork(&task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, work.lockKey)
+	w.doWork(task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, work.lockKey)
 }
 
 func (w *v3Worker) singleRun() {
@@ -149,5 +149,5 @@ func (w *v3Worker) singleRun() {
 	}
 	w.addWorkerID(task.Metadata)
 	task.Logger = task.Logger.With(zap.String("worker", w.workerID))
-	w.doWork(&task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, work.lockKey)
+	w.doWork(task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, work.lockKey)
 }

--- a/rules/worker_test.go
+++ b/rules/worker_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/stretchr/testify/assert"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 func TestWorkerSingleRun(t *testing.T) {

--- a/rules/worker_test.go
+++ b/rules/worker_test.go
@@ -30,11 +30,14 @@ func TestWorkerSingleRun(t *testing.T) {
 	attr := mapAttributes{
 		values: attrMap,
 	}
+
+	logger, _ := zap.NewProduction()
+
 	conf := client.Config{}
 	task := RuleTask{
 		Attr:     &attr,
 		Conf:     conf,
-		Logger:   zap.New(zap.NewTextEncoder()),
+		Logger:   logger,
 		Metadata: map[string]string{},
 	}
 	cbChannel := make(chan bool)


### PR DESCRIPTION
Zap logger recently issued their first release, as part of this they changed the canonical import url from `github.com/uber-go/zap` to `go.uber.org/zap`.