### PR TITLE
Add envconfig tags to EngineOptions

### DIFF
--- a/rules/options.go
+++ b/rules/options.go
@@ -16,9 +16,9 @@ func defaultContextProvider() (context.Context, context.CancelFunc) {
 
 // EngineOptions is used to configure the engine from configuration files
 type EngineOptions struct {
-	Concurrency        *int  `toml:"concurrency",envconfig:"concurrency"`
-	AutoCrawlGuides    *bool `toml:"auto_crawl_guides",envconfig:"auto_crawl_guides"`
-	EnhancedRuleFilter *bool `toml:"enhanced_rule_filter",envconfig:"enhanced_rule_filter"`
+	Concurrency        *int  `toml:"concurrency" envconfig:"concurrency"`
+	AutoCrawlGuides    *bool `toml:"auto_crawl_guides" envconfig:"auto_crawl_guides"`
+	EnhancedRuleFilter *bool `toml:"enhanced_rule_filter" envconfig:"enhanced_rule_filter"`
 }
 
 // GetEngineOptions is used to convert an EngineOptions instance into

--- a/rules/options.go
+++ b/rules/options.go
@@ -16,9 +16,9 @@ func defaultContextProvider() (context.Context, context.CancelFunc) {
 
 // EngineOptions is used to configure the engine from configuration files
 type EngineOptions struct {
-	Concurrency        *int  `toml:"concurrency"`
-	AutoCrawlGuides    *bool `toml:"auto_crawl_guides"`
-	EnhancedRuleFilter *bool `toml:"enhanced_rule_filter"`
+	Concurrency        *int  `toml:"concurrency",envconfig:"concurrency"`
+	AutoCrawlGuides    *bool `toml:"auto_crawl_guides",envconfig:"auto_crawl_guides"`
+	EnhancedRuleFilter *bool `toml:"enhanced_rule_filter",envconfig:"enhanced_rule_filter"`
 }
 
 // GetEngineOptions is used to convert an EngineOptions instance into

--- a/rules/options.go
+++ b/rules/options.go
@@ -16,7 +16,7 @@ func defaultContextProvider() (context.Context, context.CancelFunc) {
 
 // EngineOptions is used to configure the engine from configuration files
 type EngineOptions struct {
-	Concurrency        *int  `toml:"concurrency" envconfig:"concurrency"`
+	Concurrency        *int  `toml:"concurrency" envconfig:"rules_concurrency"`
 	AutoCrawlGuides    *bool `toml:"auto_crawl_guides" envconfig:"auto_crawl_guides"`
 	EnhancedRuleFilter *bool `toml:"enhanced_rule_filter" envconfig:"enhanced_rule_filter"`
 }


### PR DESCRIPTION
These tags will allow the fields of the struct to be populated from environment variables using this [library](https://github.com/kelseyhightower/envconfig).