### PR TITLE
remove zap from glide.yaml

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -5,8 +5,6 @@ import:
   - context
 - package: github.com/coreos/etcd
   version: ~3.3.0
-- package: go.uber.org/zap
-  version: ~1.7.1
 testImport:
 - package: github.com/stretchr/testify
   version: ~1.1.4


### PR DESCRIPTION
Allows the user or github.com/coreos/etcd to set the glide version.  This will remove unnecessary semver conflicts.