### PR TITLE
Add configurable lock timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export
 LINT_VERSION="1.21.0"
 
 .PHONY: all
-all: deps fmt lint test
+all: deps lint test
 
 .PHONY: deps
 deps:

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -254,6 +254,7 @@ func (e *v3Engine) Run() {
 		logger,
 		e.options.crawlMutex,
 		e.options.crawlerTTL,
+		e.options.lockAcquisitionTimeout,
 		prefixSlice,
 		e.kvWrapper,
 		e.options.syncDelay)

--- a/rules/engine_test.go
+++ b/rules/engine_test.go
@@ -64,7 +64,7 @@ func TestV3EngineConstructor(t *testing.T) {
 	eng.Run()
 	eng.Stop()
 	stopped := false
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 40; i++ {
 		stopped = eng.IsStopped()
 		if stopped {
 			break

--- a/rules/lock_test.go
+++ b/rules/lock_test.go
@@ -11,9 +11,9 @@ func TestV3Locker(t *testing.T) {
 	cfg, cl := initV3Etcd(t)
 	c, err := clientv3.New(cfg)
 	assert.NoError(t, err)
-	newV3Locker(c)
 	rlckr := v3Locker{
-		cl: cl,
+		cl:          cl,
+		lockTimeout: 5,
 	}
 	rlck, err1 := rlckr.lock("test", 10)
 	assert.NoError(t, err1)
@@ -25,7 +25,7 @@ func TestV3Locker(t *testing.T) {
 	done2 := make(chan bool)
 
 	go func() {
-		lckr := newV3Locker(c)
+		lckr := newV3Locker(c, 5)
 		lck, lErr := lckr.lock("test1", 10)
 		assert.NoError(t, lErr)
 		done1 <- true

--- a/rules/options.go
+++ b/rules/options.go
@@ -18,6 +18,7 @@ func defaultContextProvider() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), time.Minute*5)
 }
 
+// MetricsCollectorOpt ...
 type MetricsCollectorOpt func() MetricsCollector
 
 func defaultMetricsCollector() MetricsCollector {
@@ -50,28 +51,30 @@ type engineOptions struct {
 	syncGetTimeout,
 	syncInterval,
 	watchTimeout int
-	syncDelay          int
-	constraints        map[string]constraint
-	contextProvider    ContextProvider
-	keyExpansion       map[string][]string
-	lockTimeout        int
-	crawlMutex         *string
-	ruleWorkBuffer     int
-	enhancedRuleFilter bool
-	metrics            MetricsCollectorOpt
+	syncDelay              int
+	constraints            map[string]constraint
+	contextProvider        ContextProvider
+	keyExpansion           map[string][]string
+	lockTimeout            int
+	lockAcquisitionTimeout int
+	crawlMutex             *string
+	ruleWorkBuffer         int
+	enhancedRuleFilter     bool
+	metrics                MetricsCollectorOpt
 }
 
 func makeEngineOptions(options ...EngineOption) engineOptions {
 	opts := engineOptions{
-		concurrency:     5,
-		constraints:     map[string]constraint{},
-		contextProvider: defaultContextProvider,
-		syncDelay:       1,
-		lockTimeout:     30,
-		syncInterval:    300,
-		syncGetTimeout:  0,
-		watchTimeout:    0,
-		metrics:         defaultMetricsCollector,
+		concurrency:            5,
+		constraints:            map[string]constraint{},
+		contextProvider:        defaultContextProvider,
+		syncDelay:              1,
+		lockTimeout:            30,
+		lockAcquisitionTimeout: 5,
+		syncInterval:           300,
+		syncGetTimeout:         0,
+		watchTimeout:           0,
+		metrics:                defaultMetricsCollector,
 	}
 	for _, opt := range options {
 		opt.apply(&opts)
@@ -96,6 +99,14 @@ func (f engineOptionFunction) apply(o *engineOptions) {
 func EngineLockTimeout(lockTimeout int) EngineOption {
 	return engineOptionFunction(func(o *engineOptions) {
 		o.lockTimeout = lockTimeout
+	})
+}
+
+// EngineLockAcquisitionTimeout controls the length of time we
+// wait to acquire a lock.
+func EngineLockAcquisitionTimeout(lockAcquisitionTimeout int) EngineOption {
+	return engineOptionFunction(func(o *engineOptions) {
+		o.lockAcquisitionTimeout = lockAcquisitionTimeout
 	})
 }
 

--- a/rules/worker.go
+++ b/rules/worker.go
@@ -25,7 +25,7 @@ func newV3Worker(workerID string, engine *v3Engine) (v3Worker, error) {
 	var locker ruleLocker
 	c := engine.cl
 	kv := engine.kvWrapper(c)
-	locker = newV3Locker(c)
+	locker = newV3Locker(c, engine.options.lockAcquisitionTimeout)
 	api = &etcdV3ReadAPI{
 		kV: kv,
 	}


### PR DESCRIPTION
I've added a configurable timeout for taking a mutex lock so that we can performance test variations to see what is ideal. 

I've not done unlock yet as that's slightly different behaviour so would be interested to see what you think should be done there.