### PR TITLE
Observe all prefixes in metrics

### DIFF
--- a/rules/etcd.go
+++ b/rules/etcd.go
@@ -60,6 +60,7 @@ func newEtcdV3KeyWatcher(watcher clientv3.Watcher, prefix string, timeout time.D
 		w:      watcher,
 		stopCh: make(chan bool),
 	}
+	kw.metrics.ObserveWatchEvents(prefix, 0, 0)
 	return &kw
 }
 


### PR DESCRIPTION
Generate a metric even for watch prefixes that may never fire an event.
Current behavior is to not generate metric if no events.
https://github.com/IBM-Cloud/go-etcd-rules/blob/master/rules/etcd.go#L119-L130
This allows a query like  
```
count(data_etcd_operation_keys_sum{action="watch",method="rules-engine-watcher"}) by (prefix, method)
```
to show all the prefixes that are being watched, not just the ones that fire events.