### PR TITLE
Fix work channel race condition

### DIFF
--- a/rules/engine.go
+++ b/rules/engine.go
@@ -161,10 +161,10 @@ func (e *baseEngine) stop() {
 	for _, worker := range e.workers {
 		worker.stop()
 	}
-	e.logger.Debug("Closing work channel")
 	// Ensure workers are stopped; the "stop" method is called again, but
 	// that is idempotent.  The workers' "stop" method must be called before
 	// the channel is closed in order to avoid nil pointer dereference panics.
+	e.logger.Debug("Stopping workers")
 	stopstoppables(e.workers)
 	atomicSet(&e.stopped, true)
 	e.logger.Info("Engine stopped")

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -28,7 +28,6 @@ type BaseEngine interface {
 }
 
 type baseEngine struct {
-	cCloser      channelCloser
 	keyProc      setableKeyProcessor
 	metrics      AdvancedMetricsCollector
 	logger       *zap.Logger
@@ -40,8 +39,6 @@ type baseEngine struct {
 	watchers     []stoppable
 	workers      []stoppable
 }
-
-type channelCloser func()
 
 type v3Engine struct {
 	baseEngine
@@ -99,9 +96,6 @@ func newV3Engine(logger *zap.Logger, cl *clientv3.Client, options ...EngineOptio
 
 	eng := v3Engine{
 		baseEngine: baseEngine{
-			cCloser: func() {
-				close(channel)
-			},
 			keyProc:      &keyProc,
 			metrics:      metrics,
 			logger:       logger,
@@ -168,7 +162,6 @@ func (e *baseEngine) stop() {
 		worker.stop()
 	}
 	e.logger.Debug("Closing work channel")
-	e.cCloser()
 	// Ensure workers are stopped; the "stop" method is called again, but
 	// that is idempotent.  The workers' "stop" method must be called before
 	// the channel is closed in order to avoid nil pointer dereference panics.


### PR DESCRIPTION
A channel should be closed by the same goroutine that writes to it.  Since there are now multiple goroutines writing to the work channel, the channel is no longer being closed and a "done" channel with a select statement is used instead to let worker goroutines exit when the worker is shut down.