### PR TITLE
Add optional delay after a watch event is received, add default jitter to crawler

### DIFF
--- a/internal/jitter/duration.go
+++ b/internal/jitter/duration.go
@@ -1,0 +1,54 @@
+package jitter
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Duration is a time.Duration with variance. Successive calls to Next() return new randomized durations.
+// The zero-value returns 0 for every time duration.
+type Duration struct {
+	base          time.Duration
+	jitterPercent float64
+}
+
+// NewDuration returns a new Duration with a base time duration and a percentage of jitter
+func NewDuration(base time.Duration, jitterPercent float64) Duration {
+	return Duration{
+		base:          base,
+		jitterPercent: clampPercent(jitterPercent),
+	}
+}
+
+// Next returns a new, randomized duration from the interval base±jitterPercent
+func (d Duration) Next() time.Duration {
+	/*
+		Example formula:
+		base = 100ns
+		jitterPercent = 0.1 (10%)
+		Result should be within 10% of 100ns. Or: 100ns±10%
+
+		RANDOM = 0.3
+		100 + 100 * 0.1 * (2*0.3 - 1) = 96ns
+		RANDOM = 0.9
+		100 + 100 * 0.1 * (2*0.9 - 1) = 108ns
+	*/
+	var (
+		dNano           = float64(d.base.Nanoseconds())
+		random          = rand.Float64() // in range [0, 1)
+		randomPlusMinus = 2*random - 1   // in range [-0.5, 0.5)
+		resultNano      = dNano + dNano*d.jitterPercent*randomPlusMinus
+	)
+	return time.Duration(resultNano) * time.Nanosecond
+}
+
+func clampPercent(f float64) float64 {
+	switch {
+	case f < 0:
+		return 0
+	case f > 1:
+		return 1
+	default:
+		return f
+	}
+}

--- a/internal/jitter/duration.go
+++ b/internal/jitter/duration.go
@@ -5,23 +5,25 @@ import (
 	"time"
 )
 
-// Duration is a time.Duration with variance. Successive calls to Next() return new randomized durations.
-// The zero-value returns 0 for every time duration.
-type Duration struct {
+// DurationGenerator generates time.Durations with variance called "jitter".
+// Successive calls to Generate() return new randomized durations.
+//
+// The zero-value returns 0 for every duration.
+type DurationGenerator struct {
 	base          time.Duration
 	jitterPercent float64
 }
 
-// NewDuration returns a new Duration with a base time duration and a percentage of jitter
-func NewDuration(base time.Duration, jitterPercent float64) Duration {
-	return Duration{
+// NewDurationGenerator returns a new DurationGenerator with a base time duration and a percentage of jitter
+func NewDurationGenerator(base time.Duration, jitterPercent float64) DurationGenerator {
+	return DurationGenerator{
 		base:          base,
 		jitterPercent: clampPercent(jitterPercent),
 	}
 }
 
 // Next returns a new, randomized duration from the interval base±jitterPercent
-func (d Duration) Next() time.Duration {
+func (g DurationGenerator) Generate() time.Duration {
 	/*
 		Example formula:
 		base = 100ns
@@ -34,10 +36,10 @@ func (d Duration) Next() time.Duration {
 		100 + 100 * 0.1 * (2*0.9 - 1) = 108ns
 	*/
 	var (
-		dNano           = float64(d.base.Nanoseconds())
+		dNano           = float64(g.base.Nanoseconds())
 		random          = rand.Float64() // in range [0, 1)
 		randomPlusMinus = 2*random - 1   // in range [-0.5, 0.5)
-		resultNano      = dNano + dNano*d.jitterPercent*randomPlusMinus
+		resultNano      = dNano + dNano*g.jitterPercent*randomPlusMinus
 	)
 	return time.Duration(resultNano) * time.Nanosecond
 }

--- a/internal/jitter/duration.go
+++ b/internal/jitter/duration.go
@@ -1,7 +1,7 @@
 package jitter
 
 import (
-	"math/rand"
+	"math/rand" // nolint:gosec // Only generating random durations, which is not security-sensitive. A pseudo-random number generator is ok.
 	"time"
 )
 
@@ -22,7 +22,7 @@ func NewDurationGenerator(base time.Duration, jitterPercent float64) DurationGen
 	}
 }
 
-// Next returns a new, randomized duration from the interval base±jitterPercent
+// Generate returns a new, randomized duration from the interval base±jitterPercent
 func (g DurationGenerator) Generate() time.Duration {
 	/*
 		Example formula:
@@ -37,8 +37,8 @@ func (g DurationGenerator) Generate() time.Duration {
 	*/
 	var (
 		dNano           = float64(g.base.Nanoseconds())
-		random          = rand.Float64() // in range [0, 1)
-		randomPlusMinus = 2*random - 1   // in range [-0.5, 0.5)
+		random          = rand.Float64() /* in range [0, 1) */ // nolint:gosec // Generating random durations is not security-sensitive. A pseudo-random number generator is ok.
+		randomPlusMinus = 2*random - 1   /* in range [-0.5, 0.5) */
 		resultNano      = dNano + dNano*g.jitterPercent*randomPlusMinus
 	)
 	return time.Duration(resultNano) * time.Nanosecond

--- a/internal/jitter/duration_test.go
+++ b/internal/jitter/duration_test.go
@@ -1,0 +1,51 @@
+package jitter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuration(t *testing.T) {
+	for _, tc := range []struct {
+		description      string
+		duration         Duration
+		expectLowerBound time.Duration
+		expectUpperBound time.Duration
+	}{
+		{
+			description:      "happy path",
+			duration:         NewDuration(5*time.Minute, 0.2 /* 20% */),
+			expectLowerBound: 4 * time.Minute,
+			expectUpperBound: 6 * time.Minute,
+		},
+		{
+			description:      "zero value",
+			duration:         Duration{},
+			expectLowerBound: 0,
+			expectUpperBound: 0,
+		},
+		{
+			description:      "percent too high",
+			duration:         NewDuration(5*time.Minute, 100),
+			expectLowerBound: 0,
+			expectUpperBound: 10 * time.Minute,
+		},
+		{
+			description:      "percent too low",
+			duration:         NewDuration(5*time.Minute, -100),
+			expectLowerBound: 5 * time.Minute,
+			expectUpperBound: 5 * time.Minute,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			const maxAttempts = 500
+			for i := 0; i < maxAttempts; i++ {
+				d := tc.duration.Next()
+				assert.LessOrEqual(t, tc.expectLowerBound, d)
+				assert.GreaterOrEqual(t, tc.expectUpperBound, d)
+			}
+		})
+	}
+}

--- a/internal/jitter/duration_test.go
+++ b/internal/jitter/duration_test.go
@@ -10,31 +10,31 @@ import (
 func TestDuration(t *testing.T) {
 	for _, tc := range []struct {
 		description      string
-		duration         Duration
+		duration         DurationGenerator
 		expectLowerBound time.Duration
 		expectUpperBound time.Duration
 	}{
 		{
 			description:      "happy path",
-			duration:         NewDuration(5*time.Minute, 0.2 /* 20% */),
+			duration:         NewDurationGenerator(5*time.Minute, 0.2 /* 20% */),
 			expectLowerBound: 4 * time.Minute,
 			expectUpperBound: 6 * time.Minute,
 		},
 		{
 			description:      "zero value",
-			duration:         Duration{},
+			duration:         DurationGenerator{},
 			expectLowerBound: 0,
 			expectUpperBound: 0,
 		},
 		{
 			description:      "percent too high",
-			duration:         NewDuration(5*time.Minute, 100),
+			duration:         NewDurationGenerator(5*time.Minute, 100),
 			expectLowerBound: 0,
 			expectUpperBound: 10 * time.Minute,
 		},
 		{
 			description:      "percent too low",
-			duration:         NewDuration(5*time.Minute, -100),
+			duration:         NewDurationGenerator(5*time.Minute, -100),
 			expectLowerBound: 5 * time.Minute,
 			expectUpperBound: 5 * time.Minute,
 		},
@@ -42,7 +42,7 @@ func TestDuration(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			const maxAttempts = 500
 			for i := 0; i < maxAttempts; i++ {
-				d := tc.duration.Next()
+				d := tc.duration.Generate()
 				assert.LessOrEqual(t, tc.expectLowerBound, d)
 				assert.GreaterOrEqual(t, tc.expectUpperBound, d)
 			}

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -294,7 +294,7 @@ func (e *v3Engine) Run() {
 	for prefix := range prefixes {
 		prefixSlice = append(prefixSlice, prefix)
 		logger := e.logger.With(zap.String("prefix", prefix))
-		w, err := newV3Watcher(e.cl, prefix, logger, e.baseEngine.keyProc, e.options.watchTimeout, e.kvWrapper, e.metrics, e.watcherWrapper)
+		w, err := newV3Watcher(e.cl, prefix, logger, e.baseEngine.keyProc, e.options.watchTimeout, e.kvWrapper, e.metrics, e.watcherWrapper, e.options.watchDelay)
 		if err != nil {
 			e.logger.Fatal("Failed to initialize watcher", zap.String("prefix", prefix))
 		}

--- a/rules/int_crawler.go
+++ b/rules/int_crawler.go
@@ -23,7 +23,7 @@ func newIntCrawler(
 	mutexTimeout int,
 	prefixes []string,
 	kvWrapper WrapKV,
-	delay int,
+	delay jitter.DurationGenerator,
 	locker lock.RuleLocker,
 ) (crawler, error) {
 	kv := kvWrapper(cl)
@@ -74,7 +74,7 @@ type intCrawler struct {
 	cancelFunc   context.CancelFunc
 	cancelMutex  sync.Mutex
 	cl           *clientv3.Client
-	delay        int
+	delay        jitter.DurationGenerator
 	interval     jitter.DurationGenerator
 	kp           extKeyProc
 	kv           clientv3.KV
@@ -190,7 +190,7 @@ func (ic *intCrawler) processData(values map[string]string, logger *zap.Logger) 
 			// Process key if it is
 			ic.kp.processKey(k, &v, ic.api, logger, map[string]string{"source": "crawler"}, ic.incRuleProcessedCount)
 		}
-		time.Sleep(time.Duration(ic.delay) * time.Millisecond)
+		time.Sleep(ic.delay.Generate())
 	}
 }
 

--- a/rules/int_crawler.go
+++ b/rules/int_crawler.go
@@ -135,6 +135,7 @@ func (ic *intCrawler) run() {
 		}
 		logger.Info("Crawler run complete")
 		intervalSeconds := int(ic.interval.Generate().Seconds())
+		logger.Debug("Pausing before next crawler run", zap.Int("wait_time_seconds", intervalSeconds))
 		for i := 0; i < intervalSeconds; i++ {
 			time.Sleep(time.Second)
 			if ic.isStopping() {

--- a/rules/options.go
+++ b/rules/options.go
@@ -77,7 +77,7 @@ func makeEngineOptions(options ...EngineOption) engineOptions {
 		concurrency:            5,
 		constraints:            map[string]constraint{},
 		contextProvider:        defaultContextProvider,
-		syncDelay:              jitter.NewDurationGenerator(10*time.Second, syncJitterPercent),
+		syncDelay:              jitter.NewDurationGenerator(2*time.Millisecond, syncJitterPercent),
 		lockTimeout:            30,
 		lockAcquisitionTimeout: 5,
 		syncInterval:           jitter.NewDurationGenerator(5*time.Minute, syncJitterPercent),

--- a/rules/options.go
+++ b/rules/options.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"time"
 
+	"github.com/IBM-Cloud/go-etcd-rules/internal/jitter"
 	"golang.org/x/net/context"
 )
 
@@ -66,6 +67,7 @@ type engineOptions struct {
 	lockCoolOff            time.Duration
 	useSharedLockSession   bool
 	useTryLock             bool
+	watchDelay             jitter.Duration
 }
 
 func makeEngineOptions(options ...EngineOption) engineOptions {
@@ -272,6 +274,12 @@ func EngineRuleWorkBuffer(buffer int) EngineOption {
 func EngineEnhancedRuleFilter(enhancedRuleFilter bool) EngineOption {
 	return engineOptionFunction(func(o *engineOptions) {
 		o.enhancedRuleFilter = enhancedRuleFilter
+	})
+}
+
+func EngineWatchProcessDelay(base time.Duration, jitterPercent float64) EngineOption {
+	return engineOptionFunction(func(o *engineOptions) {
+		o.watchDelay = jitter.NewDuration(base, jitterPercent)
 	})
 }
 

--- a/rules/options.go
+++ b/rules/options.go
@@ -67,7 +67,7 @@ type engineOptions struct {
 	lockCoolOff            time.Duration
 	useSharedLockSession   bool
 	useTryLock             bool
-	watchDelay             jitter.Duration
+	watchDelay             jitter.DurationGenerator
 }
 
 func makeEngineOptions(options ...EngineOption) engineOptions {
@@ -279,7 +279,7 @@ func EngineEnhancedRuleFilter(enhancedRuleFilter bool) EngineOption {
 
 func EngineWatchProcessDelay(base time.Duration, jitterPercent float64) EngineOption {
 	return engineOptionFunction(func(o *engineOptions) {
-		o.watchDelay = jitter.NewDuration(base, jitterPercent)
+		o.watchDelay = jitter.NewDurationGenerator(base, jitterPercent)
 	})
 }
 

--- a/rules/options_test.go
+++ b/rules/options_test.go
@@ -27,13 +27,13 @@ func TestRuleOptions(t *testing.T) {
 func TestEngineOptions(t *testing.T) {
 	opts := makeEngineOptions()
 	assert.Equal(t, jitter.NewDurationGenerator(5*time.Minute, 0.1), opts.syncInterval)
-	assert.Equal(t, jitter.NewDurationGenerator(10*time.Second, 0.1), opts.syncDelay)
+	assert.Equal(t, jitter.NewDurationGenerator(2*time.Millisecond, 0.1), opts.syncDelay)
 	assert.Zero(t, opts.watchDelay)
 	assert.IsType(t, &noOpMetricsCollector{}, opts.metrics())
 
 	opts = makeEngineOptions(EngineSyncInterval(5))
 	assert.Equal(t, jitter.NewDurationGenerator(5*time.Second, 0.1), opts.syncInterval)
-	assert.Equal(t, jitter.NewDurationGenerator(10*time.Second, 0.1), opts.syncDelay)
+	assert.Equal(t, jitter.NewDurationGenerator(2*time.Millisecond, 0.1), opts.syncDelay)
 
 	opts = makeEngineOptions(EngineConcurrency(10))
 	assert.Equal(t, 10, opts.concurrency)

--- a/rules/watcher.go
+++ b/rules/watcher.go
@@ -4,30 +4,33 @@ import (
 	"strings"
 	"time"
 
+	"github.com/IBM-Cloud/go-etcd-rules/internal/jitter"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 )
 
-func newV3Watcher(ec *clientv3.Client, prefix string, logger *zap.Logger, proc keyProc, watchTimeout int, kvWrapper WrapKV, metrics AdvancedMetricsCollector, watcherWrapper WrapWatcher) (watcher, error) {
+func newV3Watcher(ec *clientv3.Client, prefix string, logger *zap.Logger, proc keyProc, watchTimeout int, kvWrapper WrapKV, metrics AdvancedMetricsCollector, watcherWrapper WrapWatcher, processDelay jitter.Duration) (watcher, error) {
 	api := etcdV3ReadAPI{
 		kV: kvWrapper(ec),
 	}
 	ew := newEtcdV3KeyWatcher(watcherWrapper(clientv3.NewWatcher(ec)), prefix, time.Duration(watchTimeout)*time.Second, metrics)
 	return watcher{
-		api:    &api,
-		kw:     ew,
-		kp:     proc,
-		logger: logger,
+		api:          &api,
+		kw:           ew,
+		kp:           proc,
+		logger:       logger,
+		processDelay: processDelay,
 	}, nil
 }
 
 type watcher struct {
-	api      readAPI
-	kw       keyWatcher
-	kp       keyProc
-	logger   *zap.Logger
-	stopping uint32
-	stopped  uint32
+	api          readAPI
+	kw           keyWatcher
+	kp           keyProc
+	logger       *zap.Logger
+	processDelay jitter.Duration
+	stopping     uint32
+	stopped      uint32
 }
 
 func (w *watcher) run() {
@@ -59,6 +62,11 @@ func (w *watcher) singleRun() {
 			time.Sleep(time.Second)
 		}
 		return
+	}
+	delay := w.processDelay.Next()
+	if delay > 0 {
+		w.logger.Debug("Pausing before processing next key", zap.Duration("wait_time", delay))
+		time.Sleep(delay) // TODO ideally a context should be used for fast shutdown, e.g. select { case <-ctx.Done(); case <-time.After(delay) }
 	}
 	w.logger.Debug("Calling process key", zap.String("key", key))
 	w.kp.processKey(key, value, w.api, w.logger, map[string]string{}, nil)


### PR DESCRIPTION
Adds an optional, configurable delay with jitter after a watch event is received. This option is intended to help mitigate a "thundering herd" when many watcher clients all attempt to fetch and lock on the same keys simultaneously.

I've also added a small jitter to the crawler interval and delay. This piece isn't quite as critical, but it does spread out many simultaneous crawler runs to level out the traffic peaks.