### PR TITLE
Move context timer start to task initiation

### DIFF
--- a/rules/key_processor.go
+++ b/rules/key_processor.go
@@ -58,12 +58,9 @@ func (v3kp *v3KeyProcessor) setCallback(index int, callback interface{}) {
 }
 
 func (v3kp *v3KeyProcessor) dispatchWork(index int, rule staticRule, logger *zap.Logger, keyPattern string, metadata map[string]string, ruleID string) {
-	context, cancelFunc := v3kp.contextProviders[index]()
 	task := V3RuleTask{
 		Attr:     rule.getAttributes(),
 		Logger:   logger,
-		Context:  context,
-		cancel:   cancelFunc,
 		Metadata: metadata,
 	}
 	work := v3RuleWork{
@@ -72,8 +69,11 @@ func (v3kp *v3KeyProcessor) dispatchWork(index int, rule staticRule, logger *zap
 		ruleIndex:        index,
 		ruleTask:         task,
 		ruleTaskCallback: v3kp.callbacks[index],
-		metricsInfo:      newMetricsInfo(context, keyPattern),
 		lockKey:          FormatWithAttributes(keyPattern, rule.getAttributes()),
+
+		// context info
+		keyPattern:      keyPattern,
+		contextProvider: v3kp.contextProviders[index],
 	}
 
 	start := time.Now()

--- a/rules/key_processor.go
+++ b/rules/key_processor.go
@@ -72,8 +72,9 @@ func (v3kp *v3KeyProcessor) dispatchWork(index int, rule staticRule, logger *zap
 		lockKey:          FormatWithAttributes(keyPattern, rule.getAttributes()),
 
 		// context info
-		keyPattern:      keyPattern,
-		contextProvider: v3kp.contextProviders[index],
+		keyPattern:       keyPattern,
+		metricsStartTime: time.Now(),
+		contextProvider:  v3kp.contextProviders[index],
 	}
 
 	start := time.Now()

--- a/rules/key_processor.go
+++ b/rules/key_processor.go
@@ -80,7 +80,7 @@ func (v3kp *v3KeyProcessor) dispatchWork(index int, rule staticRule, logger *zap
 	start := time.Now()
 	v3kp.channel <- work
 	// measures the amount of time work is blocked from being added to the buffer
-	metrics.WorkBufferWaitTime(work.metricsInfo.method, keyPattern, start)
+	metrics.WorkBufferWaitTime(getMethodNameFromProvider(work.contextProvider), keyPattern, start)
 }
 
 func newV3KeyProcessor(channel chan v3RuleWork, rm *ruleManager, kpChannel chan *keyTask, concurrency int, logger *zap.Logger) v3KeyProcessor {

--- a/rules/metrics_collector.go
+++ b/rules/metrics_collector.go
@@ -19,7 +19,7 @@ type metricsInfo struct {
 	startTime time.Time
 }
 
-func newMetricsInfo(ctx context.Context, keyPattern string) metricsInfo {
+func newMetricsInfo(ctx context.Context, keyPattern string, startTime time.Time) metricsInfo {
 	methodName := notSetMethodName
 	if data := GetMetricsMetadata(ctx); data != nil {
 		methodName = data.Method
@@ -27,7 +27,7 @@ func newMetricsInfo(ctx context.Context, keyPattern string) metricsInfo {
 	return metricsInfo{
 		keyPattern: keyPattern,
 		method:     methodName,
-		startTime:  time.Now(),
+		startTime:  startTime,
 	}
 }
 

--- a/rules/metrics_collector.go
+++ b/rules/metrics_collector.go
@@ -20,15 +20,24 @@ type metricsInfo struct {
 }
 
 func newMetricsInfo(ctx context.Context, keyPattern string, startTime time.Time) metricsInfo {
+	return metricsInfo{
+		keyPattern: keyPattern,
+		method:     getMethodNameFromContext(ctx),
+		startTime:  startTime,
+	}
+}
+
+func getMethodNameFromProvider(cp ContextProvider) string {
+	ctx, _ := cp()
+	return getMethodNameFromContext(ctx)
+}
+
+func getMethodNameFromContext(ctx context.Context) string {
 	methodName := notSetMethodName
 	if data := GetMetricsMetadata(ctx); data != nil {
 		methodName = data.Method
 	}
-	return metricsInfo{
-		keyPattern: keyPattern,
-		method:     methodName,
-		startTime:  startTime,
-	}
+	return methodName
 }
 
 // MetricsCollector used for collecting metrics, implement this interface using

--- a/rules/metrics_collector_test.go
+++ b/rules/metrics_collector_test.go
@@ -2,9 +2,10 @@ package rules
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewMetricsInfo(t *testing.T) {
@@ -28,7 +29,8 @@ func TestNewMetricsInfo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mi := newMetricsInfo(tc.ctx, tc.pattern)
+			startTime := time.Now()
+			mi := newMetricsInfo(tc.ctx, tc.pattern, startTime)
 			assert.Equal(t, tc.expectedMethodName, mi.method)
 			assert.Equal(t, tc.pattern, mi.keyPattern)
 			assert.True(t, time.Since(mi.startTime) < (1*time.Minute))

--- a/rules/task.go
+++ b/rules/task.go
@@ -43,7 +43,6 @@ type v3RuleWork struct {
 	ruleTask         V3RuleTask
 	ruleTaskCallback V3RuleTaskCallback
 	ruleIndex        int
-	metricsInfo      metricsInfo
 	lockKey          string
 	// context handling
 	keyPattern       string

--- a/rules/task.go
+++ b/rules/task.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"time"
+
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
@@ -44,6 +46,7 @@ type v3RuleWork struct {
 	metricsInfo      metricsInfo
 	lockKey          string
 	// context handling
-	keyPattern      string
-	contextProvider ContextProvider
+	keyPattern       string
+	metricsStartTime time.Time
+	contextProvider  ContextProvider
 }

--- a/rules/task.go
+++ b/rules/task.go
@@ -43,4 +43,7 @@ type v3RuleWork struct {
 	ruleIndex        int
 	metricsInfo      metricsInfo
 	lockKey          string
+	// context handling
+	keyPattern      string
+	contextProvider ContextProvider
 }

--- a/rules/worker.go
+++ b/rules/worker.go
@@ -179,7 +179,7 @@ func (w *v3Worker) singleRun() {
 		context, cancelFunc := work.contextProvider()
 		task.Context = context
 		task.cancel = cancelFunc
-		work.metricsInfo = newMetricsInfo(context, work.keyPattern)
+		work.metricsInfo = newMetricsInfo(context, work.keyPattern, work.metricsStartTime)
 		w.doWork(&task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, work.metricsInfo, work.lockKey, work.ruleID)
 	}()
 	wg.Wait()

--- a/rules/worker.go
+++ b/rules/worker.go
@@ -175,6 +175,11 @@ func (w *v3Worker) singleRun() {
 				task.Logger.Error("Panic", zap.Any("recover", r), zap.Stack("stack"))
 			}
 		}()
+		// Get/populate context for task as callback is started
+		context, cancelFunc := work.contextProvider()
+		task.Context = context
+		task.cancel = cancelFunc
+		work.metricsInfo = newMetricsInfo(context, work.keyPattern)
 		w.doWork(&task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, work.metricsInfo, work.lockKey, work.ruleID)
 	}()
 	wg.Wait()

--- a/rules/worker.go
+++ b/rules/worker.go
@@ -179,8 +179,8 @@ func (w *v3Worker) singleRun() {
 		context, cancelFunc := work.contextProvider()
 		task.Context = context
 		task.cancel = cancelFunc
-		work.metricsInfo = newMetricsInfo(context, work.keyPattern, work.metricsStartTime)
-		w.doWork(&task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, work.metricsInfo, work.lockKey, work.ruleID)
+		metricsInfo := newMetricsInfo(context, work.keyPattern, work.metricsStartTime)
+		w.doWork(&task.Logger, &work.rule, w.engine.getLockTTLForRule(work.ruleIndex), func() { work.ruleTaskCallback(&task) }, metricsInfo, work.lockKey, work.ruleID)
 	}()
 	wg.Wait()
 }


### PR DESCRIPTION
This moves the task context to be initialized when the task is actually started, rather than when it is added into the queue.