### PR TITLE
Tweak crawler logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test: int-setup
 
 .PHONY: int-setup
 int-setup: int-teardown
-	docker run -d -p 2379:2379 --name etcd quay.io/coreos/etcd:v3.5.6 \
+	docker run -d -p 2379:2379 --name etcd quay.io/coreos/etcd:v3.5.9 \
 		/usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 \
 		--advertise-client-urls http://0.0.0.0:2379
 

--- a/internal/jitter/duration.go
+++ b/internal/jitter/duration.go
@@ -3,6 +3,8 @@ package jitter
 import (
 	"math/rand" // nolint:gosec // Only generating random durations, which is not security-sensitive. A pseudo-random number generator is ok.
 	"time"
+
+	"go.uber.org/zap/zapcore"
 )
 
 // DurationGenerator generates time.Durations with variance called "jitter".
@@ -12,6 +14,13 @@ import (
 type DurationGenerator struct {
 	base          time.Duration
 	jitterPercent float64
+}
+
+// MarshalLogObject allow zap logging
+func (g *DurationGenerator) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt("base", int(g.base.Seconds()))
+	enc.AddFloat64("jitterPercent", g.jitterPercent)
+	return nil
 }
 
 // NewDurationGenerator returns a new DurationGenerator with a base time duration and a percentage of jitter

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -291,6 +291,7 @@ func (e *baseEngine) addRule(rule DynamicRule,
 }
 
 func (e *v3Engine) Run() {
+	e.logger.Info("Rules engine options", zap.Object("options", &e.options))
 	prefixSlice := []string{}
 	prefixes := e.ruleMgr.prefixes
 	// This is a map; used to ensure there are no duplicates

--- a/rules/int_crawler.go
+++ b/rules/int_crawler.go
@@ -126,6 +126,8 @@ func (ic *intCrawler) run() {
 			if err != nil {
 				logger.Debug("Could not obtain mutex; skipping crawler run", zap.Error(err), zap.String("mutex", mutex))
 			} else {
+				logger.Debug("Crawler mutex obtained", zap.String("mutex", mutex))
+				time.Sleep(30 * time.Second)
 				ic.singleRun(logger)
 				err := lock.Unlock()
 				if err != nil {
@@ -133,7 +135,6 @@ func (ic *intCrawler) run() {
 				}
 			}
 		}
-		logger.Info("Crawler run complete")
 		intervalSeconds := int(ic.interval.Generate().Seconds())
 		logger.Debug("Pausing before next crawler run", zap.Int("wait_time_seconds", intervalSeconds))
 		for i := 0; i < intervalSeconds; i++ {
@@ -178,6 +179,7 @@ func (ic *intCrawler) singleRun(logger *zap.Logger) {
 		metrics.TimesEvaluated(crawlerMethodName, ruleID, count)
 		ic.metrics.TimesEvaluated(crawlerMethodName, ruleID, count)
 	}
+	logger.Info("Crawler run complete")
 }
 func (ic *intCrawler) processData(values map[string]string, logger *zap.Logger) {
 	api := &cacheReadAPI{values: values}

--- a/rules/int_crawler.go
+++ b/rules/int_crawler.go
@@ -111,23 +111,18 @@ func (ic *intCrawler) isStopped() bool {
 func (ic *intCrawler) run() {
 	atomicSet(&ic.stopped, false)
 	for !ic.isStopping() {
-		logger := ic.logger.With(
-			zap.String("source", "crawler"),
-			zap.String("crawler_start", time.Now().Format("2006-01-02T15:04:05-0700")),
-		)
-		logger.Info("Starting crawler run", zap.Int("prefixes", len(ic.prefixes)))
+		logger := ic.logger.With(zap.String("source", "crawler"))
 		if ic.mutex == nil {
 			ic.singleRun(logger)
 		} else {
 			mutex := "/crawler/" + *ic.mutex
-			logger.Debug("Attempting to obtain mutex",
+			logger.Info("Attempting to obtain mutex",
 				zap.String("mutex", mutex), zap.Int("Timeout", ic.mutexTimeout))
 			lock, err := ic.locker.Lock(mutex, lock.MethodForLock("crawler"), lock.PatternForLock(mutex))
 			if err != nil {
-				logger.Debug("Could not obtain mutex; skipping crawler run", zap.Error(err), zap.String("mutex", mutex))
+				logger.Error("Could not obtain mutex; skipping crawler run", zap.Error(err), zap.String("mutex", mutex))
 			} else {
-				logger.Debug("Crawler mutex obtained", zap.String("mutex", mutex))
-				time.Sleep(30 * time.Second)
+				logger.Info("Crawler mutex obtained", zap.String("mutex", mutex))
 				ic.singleRun(logger)
 				err := lock.Unlock()
 				if err != nil {
@@ -148,6 +143,7 @@ func (ic *intCrawler) run() {
 }
 
 func (ic *intCrawler) singleRun(logger *zap.Logger) {
+	logger.Info("Starting crawler run", zap.Int("prefixes", len(ic.prefixes)))
 	crawlerMethodName := "crawler"
 	if ic.isStopping() {
 		return

--- a/rules/options.go
+++ b/rules/options.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/IBM-Cloud/go-etcd-rules/internal/jitter"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/context"
 )
 
@@ -70,6 +71,44 @@ type engineOptions struct {
 	useSharedLockSession   bool
 	useTryLock             bool
 	watchDelay             jitter.DurationGenerator
+}
+
+// MarshalLogObject allow zap logging
+func (eo *engineOptions) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	enc.AddInt("concurrency", eo.concurrency)
+	enc.AddInt("ruleWorkBuffer", eo.ruleWorkBuffer)
+	enc.AddBool("contextProvider", eo.contextProvider != nil)
+	if err = enc.AddObject("syncInterval", &eo.syncInterval); err != nil {
+		return
+	}
+	if err = enc.AddObject("syncDelay", &eo.syncDelay); err != nil {
+		return
+	}
+	enc.AddInt("syncGetTimeout", eo.syncGetTimeout)
+	enc.AddInt("watchTimeout", eo.watchTimeout)
+	if err = enc.AddObject("watchDelay", &eo.watchDelay); err != nil {
+		return
+	}
+	enc.AddInt("lockTimeout", eo.lockTimeout)
+	enc.AddInt("lockAcquisitionTimeout", eo.lockAcquisitionTimeout)
+	enc.AddInt("lockCoolOff", int(eo.lockCoolOff.Seconds()))
+	if eo.crawlMutex != nil {
+		enc.AddString("crawlMutex", *eo.crawlMutex)
+		enc.AddInt("crawlerTTL", eo.crawlerTTL)
+	}
+	if err = enc.AddReflected("constraints", eo.constraints); err != nil {
+		return
+	}
+	if err = enc.AddReflected("keyExpansion", eo.keyExpansion); err != nil {
+		return
+	}
+
+	enc.AddInt("keyProcConcurrency", eo.keyProcConcurrency)
+	enc.AddInt("keyProcBuffer", eo.keyProcBuffer)
+	enc.AddBool("enhancedRuleFilter", eo.enhancedRuleFilter)
+	enc.AddBool("useSharedLockSession", eo.useSharedLockSession)
+	enc.AddBool("useTryLock", eo.useTryLock)
+	return nil
 }
 
 func makeEngineOptions(options ...EngineOption) engineOptions {


### PR DESCRIPTION

- Tweak crawler logging to be more precise
- Dump rule engine options
- Allow optional port on test cmd to allow for single and multiple crawler testing in the future