### PR TITLE
Make shared lock session default

### DIFF
--- a/rules/options.go
+++ b/rules/options.go
@@ -58,19 +58,19 @@ type engineOptions struct {
 	keyProcBuffer int
 	syncInterval,
 	syncDelay jitter.DurationGenerator
-	constraints            map[string]constraint
-	contextProvider        ContextProvider
-	keyExpansion           map[string][]string
-	lockTimeout            int
-	lockAcquisitionTimeout int
-	crawlMutex             *string
-	ruleWorkBuffer         int
-	enhancedRuleFilter     bool
-	metrics                MetricsCollectorOpt
-	lockCoolOff            time.Duration
-	useSharedLockSession   bool
-	useTryLock             bool
-	watchDelay             jitter.DurationGenerator
+	constraints              map[string]constraint
+	contextProvider          ContextProvider
+	keyExpansion             map[string][]string
+	lockTimeout              int
+	lockAcquisitionTimeout   int
+	crawlMutex               *string
+	ruleWorkBuffer           int
+	enhancedRuleFilter       bool
+	metrics                  MetricsCollectorOpt
+	lockCoolOff              time.Duration
+	dontUseSharedLockSession bool
+	useTryLock               bool
+	watchDelay               jitter.DurationGenerator
 }
 
 // MarshalLogObject allow zap logging
@@ -106,7 +106,7 @@ func (eo *engineOptions) MarshalLogObject(enc zapcore.ObjectEncoder) (err error)
 	enc.AddInt("keyProcConcurrency", eo.keyProcConcurrency)
 	enc.AddInt("keyProcBuffer", eo.keyProcBuffer)
 	enc.AddBool("enhancedRuleFilter", eo.enhancedRuleFilter)
-	enc.AddBool("useSharedLockSession", eo.useSharedLockSession)
+	enc.AddBool("dontUseSharedLockSession", eo.dontUseSharedLockSession)
 	enc.AddBool("useTryLock", eo.useTryLock)
 	return nil
 }
@@ -235,12 +235,11 @@ func EngineUseTryLock() EngineOption {
 	})
 }
 
-// EngineUseSharedLockSession is an experimental option to use a single concurrency
-// session for managing locks to reduce the ETCD load by eliminating the need to
-// create new concurrency session for each locking attempt.
-func EngineUseSharedLockSession() EngineOption {
+// EngineDontShareLockSession forces ETCD to create a new concurrency session for each
+// locking attempt. This can increase the load on ETCD.
+func EngineDontShareLockSession() EngineOption {
 	return engineOptionFunction(func(o *engineOptions) {
-		o.useSharedLockSession = true
+		o.dontUseSharedLockSession = true
 	})
 }
 

--- a/rules/options.go
+++ b/rules/options.go
@@ -235,6 +235,14 @@ func EngineUseTryLock() EngineOption {
 	})
 }
 
+// EngineUseSharedLockSession is an experimental option to use a single concurrency
+// session for managing locks to reduce the ETCD load by eliminating the need to
+// create new concurrency session for each locking attempt.
+// Deprecated: This option is now used by default.
+func EngineUseSharedLockSession() EngineOption {
+	return engineOptionFunction(func(o *engineOptions) {})
+}
+
 // EngineDontShareLockSession forces ETCD to create a new concurrency session for each
 // locking attempt. This can increase the load on ETCD.
 func EngineDontShareLockSession() EngineOption {

--- a/rules/options_test.go
+++ b/rules/options_test.go
@@ -75,6 +75,13 @@ func TestEngineOptions(t *testing.T) {
 
 	opts = makeEngineOptions(EngineWatchProcessDelay(10*time.Minute, 0.2))
 	assert.Equal(t, jitter.NewDurationGenerator(10*time.Minute, 0.2), opts.watchDelay)
+
+	optsBlank := makeEngineOptions()
+	opts = makeEngineOptions(EngineUseSharedLockSession())
+	assert.Equal(t, optsBlank.dontUseSharedLockSession, opts.dontUseSharedLockSession)
+	opts = makeEngineOptions(EngineDontShareLockSession())
+	assert.Equal(t, true, opts.dontUseSharedLockSession)
+
 }
 
 var contextKeyTest = contextKey("test")

--- a/v3enginetest/main.go
+++ b/v3enginetest/main.go
@@ -99,8 +99,7 @@ func main() {
 		rules.EngineMetricsCollector(mFunc),
 		rules.EngineSyncInterval(5),
 		rules.EngineCrawlMutex("inttest", 5),
-		rules.EngineLockAcquisitionTimeout(5),
-		rules.EngineUseSharedLockSession())
+		rules.EngineLockAcquisitionTimeout(5))
 	mw := &rules.MockWatcherWrapper{
 		Logger:    logger,
 		Responses: []v3.WatchResponse{},


### PR DESCRIPTION
This makes the improved shared lock session behavior the default, and adds an option to revert back to the previous functionality